### PR TITLE
Add all active challenges to default challenge session name if possible

### DIFF
--- a/src/ui/rename-run-ui-handler.ts
+++ b/src/ui/rename-run-ui-handler.ts
@@ -3,7 +3,7 @@ import type { InputFieldConfig } from "./form-modal-ui-handler";
 import { FormModalUiHandler } from "./form-modal-ui-handler";
 import type { ModalConfig } from "./modal-ui-handler";
 
-export default class RenameRunFormUiHandler extends FormModalUiHandler {
+export class RenameRunFormUiHandler extends FormModalUiHandler {
   getModalTitle(_config?: ModalConfig): string {
     return i18next.t("menu:renamerun");
   }

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -60,7 +60,7 @@ import { addWindow } from "#ui/ui-theme";
 import { UnavailableModalUiHandler } from "#ui/unavailable-modal-ui-handler";
 import { executeIf } from "#utils/common";
 import i18next from "i18next";
-import RenameRunFormUiHandler from "./rename-run-ui-handler";
+import { RenameRunFormUiHandler } from "./rename-run-ui-handler";
 
 const transitionModes = [
   UiMode.SAVE_SLOT,


### PR DESCRIPTION
If more than 3 challenges are active, only the first 3 are added to the name (to prevent the text going off-screen) and then "..." is appended to the end to indicate
there were more challenges active than the ones listed